### PR TITLE
add arr-includes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@
 * [arr-diff](https://github.com/jonschlinkert/arr-diff) - Returns an array with only the unique values from the first array, by excluding all values from additional arrays using strict equality for comparisons.
 * [filled-array](https://github.com/sindresorhus/filled-array) - Returns an array filled with the specified input
 * [map-array](https://github.com/parro-it/map-array) - Map object keys and values into an array.
+* [arr-includes](https://github.com/tunnckoCore/arr-includes) - Returns `true` if any of passed values exists in array. Using `in-array`.
 
 ### String
 


### PR DESCRIPTION
It's not spec compiliant - for that we have `array-includes`, which is awesome. I just needed to have some fast, focused and small thing to check is any opf multiple values exists in given array.

It's like `arr.indexOf`, but with added support for multiple values - it uses `in-array` (#12) 
