### PR TITLE
added static-props

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@
 * [is-empty-object](https://github.com/gummesson/is-empty-object) - Check if an object is empty.
 * [stringify-object](https://github.com/yeoman/stringify-object) - Stringify an object/array like JSON.stringify just without all the double-quotes.
 * [sorted-object](https://github.com/domenic/sorted-object) - Returns a copy of an object with its keys sorted.
+* [static-props](https://github.com/fibo/static-props) - Defines static object attributes using `Object.defineProperties`
 
 ### Function
 


### PR DESCRIPTION
This package uses `Object.defineProperties` to set attributes that are not configurable nor writable.

Follows an example

```
'use strict'

var staticProps = require('static-props')

class Point2d {
  constructor (x, y, label) {
    // Suppose you have few static attributes in your class.
    const color = 'red'

    // Add constant attributes quickly.
    staticProps(this)({label, color})

    // Add enumerable attributes.
    var enumerable = true
    staticProps(this)({x, y}, enumerable)
  }
}
```
