### PR TITLE
Switching link to the node-uuid package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@
 
 ### Other
 
-* [uuid](https://github.com/broofa/node-uuid) - Generate RFC-compliant UUIDs in JavaScript.
+* [uuid](https://github.com/kelektiv/node-uuid) - Generate RFC-compliant UUIDs in JavaScript.
 * [node-mime](https://github.com/broofa/node-mime) - Comprehensive MIME type mapping API based on mime-db module.
 * [not-defined](https://github.com/fibo/not-defined) - Checks if foo is not defined, i.e. undefined, null, an empty string, array or object.
 * [is-fqdn](https://github.com/parro-it/is-fqdn) - Check if a string represent a fully qualified domain name.


### PR DESCRIPTION
From what I can tell, the kelektiv version of the package is the real one and broofa is a fork. Correct me if I'm wrong and there's a reason you linked to broofa's version.

Thanks for collecting these links!