### PR TITLE
add mime-type-check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,7 @@
 * [not-defined](https://github.com/fibo/not-defined) - Checks if foo is not defined, i.e. undefined, null, an empty string, array or object.
 * [is-fqdn](https://github.com/parro-it/is-fqdn) - Check if a string represent a fully qualified domain name.
 * [shurley](https://github.com/BrunoBernardino/shurley) - Parses URLs from user input (with potential typos in protocols, bad copy+paste, etc.) and returns a proper URL.
+* [mime-type-check](https://github.com/RocktimSaikia/mime-type-check) - Get the MIME type of a file by its extension.
 
 ## Related lists
 


### PR DESCRIPTION
[mime-type-check](https://github.com/RocktimSaikia/mime-type-check) is tiny zero dependency module that returns the `MIME type` of a given file by checking its extension. Both remote and local path works fine.

ex:
```js
const getMimeType = require('mime-type-check');

getMimeType('./images/profile.svg');
//=> 'image/svg+xml'

getMimeType('https://rocktim.xyz/images/profile.svg');
//=> 'image/svg+xml'
```
[PS: Valid test cases are added]