### PR TITLE
Add color-scheme-switcher: Set color scheme automatically or manually with React context and hooks.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,7 @@
 * [get-media-size](https://github.com/bfred-it/get-media-size) - Get the original size of any `img`/`video`/`svg`/`canvas` tags or canvas context.
 * [document-ready](https://github.com/bendrucker/document-ready) - Document ready listener for modern browsers.
 * [copee](https://github.com/styfle/copee) - Copy text from browser to clipboard...natively!
+* [color-scheme-switcher](https://github.com/Californian/color-scheme-switcher) - Color scheme switcher for react. Sets color scheme either manually or automatically, based on system color scheme or the sun.
 
 ### Semver
 


### PR DESCRIPTION
[color-scheme-switcher](https://github.com/Californian/color-scheme-switcher/)

Tiny, 0-dependency package to set color scheme in React either manually or automatically, based on system color scheme or the sun.

This library is careful not to request geolocation permissions, which could be intrusive to users, unless it will be used.